### PR TITLE
Topic/dt 464 add copy to config dict

### DIFF
--- a/janrain/capture/config.py
+++ b/janrain/capture/config.py
@@ -141,6 +141,7 @@ def read_config_file():
     return config
 
 from collections import MutableMapping
+import copy
 
 class ConfigDict(MutableMapping):
     def __init__(self, file, values={ }, root = ''):
@@ -192,3 +193,6 @@ class ConfigDict(MutableMapping):
             return repr(self.values)
         else:
             return "ConfigDict{}".format(repr((self.file, self.values)))
+
+    def copy(self):
+        return copy.copy(self)

--- a/janrain/capture/config.py
+++ b/janrain/capture/config.py
@@ -20,7 +20,7 @@ def get_settings_at_path(dot_path):
     current = yaml_dict
     for chunk in dot_path.split('.'):
         current = current[chunk]
-    return current
+    return dict(current)
 
 def default_client():
     """
@@ -141,7 +141,6 @@ def read_config_file():
     return config
 
 from collections import MutableMapping
-import copy
 
 class ConfigDict(MutableMapping):
     def __init__(self, file, values={ }, root = ''):
@@ -194,5 +193,3 @@ class ConfigDict(MutableMapping):
         else:
             return "ConfigDict{}".format(repr((self.file, self.values)))
 
-    def copy(self):
-        return copy.copy(self)

--- a/janrain/capture/test/test_config.py
+++ b/janrain/capture/test/test_config.py
@@ -15,11 +15,13 @@ class TestConfig(unittest.TestCase):
     def test_clusters(self):
         # test referencing clusters
         cluster = config.get_cluster("dev")
+        self.assertTrue(isinstance(cluster, dict))
         self.assertIn('client_id', cluster)
 
     def test_merging(self):
         # test merging clusters into clients
         client = config.get_client("cluster-client")
+        self.assertTrue(isinstance(client, dict))
         self.assertEqual(client['client_id'], 'dev client_id')
         # client settings should not be overwritten
         self.assertEqual(client['apid_uri'], 'https://cluster.example.com')
@@ -29,6 +31,7 @@ class TestConfig(unittest.TestCase):
         clients = []
         clients.append(config.default_client())
         for client in clients:
+            self.assertTrue(isinstance(client, dict))
             self.assertIn('client_id', client)
             self.assertIn('client_secret', client)
             self.assertIn('apid_uri', client)
@@ -36,11 +39,13 @@ class TestConfig(unittest.TestCase):
     def test_settings(self):
         # test looking up clusters or clients without specifying which
         settings = config.get_settings('dev')
+        self.assertTrue(isinstance(settings, dict))
         self.assertEqual(settings['client_id'], "dev client_id")
 
     def test_resolving_keys(self):
         # test resolving keys using dot-notation
         client = config.get_settings_at_path("some.arbitrary.path")
+        self.assertTrue(isinstance(client, dict))
         self.assertEqual(client['foo'], "bar")
 
         with self.assertRaises(JanrainConfigError):


### PR DESCRIPTION
It seems the core issue is with config.py returning ConfigDicts instead of generic python dictionaries. I modified the library to return a standard dictionary when a matching config is found.