### PR TITLE
Removed copyright symbol from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,4 +148,4 @@ This software follows Semantic Versioning convention.
 http://semver.org/
 
 
-Copyright © 2014 Janrain, Inc. All Rights Reserved.
+Copyright (c) 2014 Janrain, Inc. All Rights Reserved.

--- a/janrain/capture/config.py
+++ b/janrain/capture/config.py
@@ -134,9 +134,9 @@ def read_config_file():
     config = ConfigDict(file, yaml_dict)
     # merge clusters into clients
     if 'clusters' in config and 'clients' in config:
-        for client in config['clients'].itervalues():
+        for client in config['clients'].values():
             if 'cluster' in client:
-                for key, value in config['clusters'][client['cluster']].iteritems():
+                for key, value in config['clusters'][client['cluster']].items():
                     client.setdefault(key, value)
     return config
 

--- a/janrain/capture/version.py
+++ b/janrain/capture/version.py
@@ -1,4 +1,4 @@
-VERSION = (0, 4, 0)
+VERSION = (0, 4, 1)
 
 def get_version():
     return "%s.%s.%s" % (VERSION[0], VERSION[1], VERSION[2])


### PR DESCRIPTION
I'm seeing some funky ASCII decoding issue when trying to install this library with Python 3.4, and it seems to be due to this copyright symbol.