### PR TITLE
Add request_timeout kwarg to capture.api.Api

### DIFF
--- a/janrain/capture/api.py
+++ b/janrain/capture/api.py
@@ -153,7 +153,7 @@ class Api(object):
         count = api.call("entity.count", type_name="user")
     """
     def __init__(self, api_url, defaults={}, compress=True, sign_requests=True,
-                 user_agent=None):
+                 user_agent=None, request_timeout=None):
 
         if api_url[0:4] == "http":
             self.api_url = api_url
@@ -163,6 +163,7 @@ class Api(object):
         self.defaults = defaults
         self.sign_requests = sign_requests
         self.compress = compress
+        self.request_timeout = request_timeout
 
         if not user_agent:
             self.user_agent = "janrain-python-api {}".format(get_version())
@@ -221,7 +222,7 @@ class Api(object):
 
         # Let any exceptions here get raised to the calling code. This includes
         # things like connection errors and timeouts.
-        r = requests.post(url, headers=headers, data=params)
+        r = requests.post(url, headers=headers, data=params, timeout=self.request_timeout)
 
         try:
             raise_api_exceptions(r.json())

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
     ],
     setup_requires=[
         'Nose',
+        'mock',
     ],
 )


### PR DESCRIPTION
We ran into an issue when making calls in a celery task where we'd get occasional zombie workers, we think this was being caused by the lack of a timeout on the request itself. As noted in [requests documentation](http://docs.python-requests.org/en/master/user/quickstart/): 

```Note
timeout is not a time limit on the entire response download; rather, an exception is raised if the server has not issued a response for timeout seconds (more precisely, if no bytes have been received on the underlying socket for timeout seconds). **If no timeout is specified explicitly, requests do not time out.**```

This adds a `request_timeout` parameter to `capture.api.Api` which is passed directly to `requests.post`.